### PR TITLE
Made PostgresConfig interoperable with ConnectInfo from the PostgresSimple library

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                arbor-postgres
-version:             0.0.2
+version:             0.0.3
 github:              "arbor/arbor-postgres"
 license:             MIT
 category:            Services

--- a/src/Arbor/Postgres/Config.hs
+++ b/src/Arbor/Postgres/Config.hs
@@ -2,11 +2,20 @@
 {-# LANGUAGE DeriveGeneric   #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module Arbor.Postgres.Config where
+module Arbor.Postgres.Config
+  ( optsPostgresConfig
+  , optsConnectInfo
+  , configToConnectInfo
+  , connectInfoToConfig
+  , PostgresConfig (..)
+  )
+where
 
 import Arbor.Postgres.Password
-import Data.Semigroup          ((<>))
-import Data.Text               (Text)
+import Data.Semigroup             ((<>))
+import Data.String                (IsString)
+import Data.Text                  (Text, pack, unpack)
+import Database.PostgreSQL.Simple as PG
 import GHC.Generics
 import Options.Applicative
 
@@ -17,27 +26,72 @@ data PostgresConfig = PostgresConfig
   , password :: Maybe Password
   } deriving (Eq, Show, Generic)
 
+hostOption :: IsString s => String -> Parser s
+hostOption prefix = strOption
+  (  long (prefix <> "-db-host")
+  <> metavar "DB_HOST"
+  <> help "The postgres hostname"
+  )
+
+databaseOption :: IsString s => String -> Parser s
+databaseOption prefix = strOption
+  (  long (prefix <> "-db-name")
+  <> metavar "DB_NAME"
+  <> help "The postgres db name"
+  )
+
+userOption :: IsString s => String -> Parser s
+userOption prefix = strOption
+  (  long (prefix <> "-db-user")
+  <> metavar "DB_USER"
+  <> help "The postgres user"
+  )
+
+passwordOption :: IsString s => String -> Parser s
+passwordOption prefix = strOption
+  (  long (prefix <> "-db-password")
+  <> metavar "DB_PASSWORD"
+  <> help "The postgres password"
+  )
+
 optsPostgresConfig :: String -> Parser PostgresConfig
 optsPostgresConfig prefix = do
-  host <- strOption
-    (  long (prefix <> "-db-host")
-    <> metavar "DB_HOST"
-    <> help "The postgres hostname"
-    )
-  database <- strOption
-    (  long (prefix <> "-db-name")
-    <> metavar "DB_NAME"
-    <> help "The postgres db name"
-    )
-  user <- strOption
-    (  long (prefix <> "-db-user")
-    <> metavar "DB_USER"
-    <> help "The postgres user"
-    )
-  password <- optional $ Password <$> strOption
-    (  long (prefix <> "-db-password")
-    <> metavar "DB_PASSWORD"
-    <> help "The postgres password"
-    )
+  host     <- hostOption prefix
+  database <- databaseOption prefix
+  user     <- userOption prefix
+  password <- optional $ Password <$> passwordOption prefix
   return PostgresConfig {..}
 
+optsConnectInfo :: String -> Parser PG.ConnectInfo
+optsConnectInfo prefix = do
+  let connectPort = 5432
+  connectHost     <- hostOption prefix
+  connectDatabase <- databaseOption prefix
+  connectUser     <- userOption prefix
+  connectPassword <- passwordOption prefix
+  return PG.ConnectInfo {..}
+
+configToConnectInfo :: PostgresConfig  -> PG.ConnectInfo
+configToConnectInfo pgc =
+  let pass = case password pgc of
+              Nothing           -> ""
+              Just (Password p) -> p
+  in ConnectInfo
+    { connectHost = unpack $ host pgc
+    , connectDatabase = unpack $ database pgc
+    , connectUser = unpack $ user pgc
+    , connectPassword = unpack pass
+    , connectPort = 5432
+    }
+
+connectInfoToConfig :: PG.ConnectInfo -> PostgresConfig
+connectInfoToConfig pgc =
+  let pass = case connectPassword pgc of
+              "" -> Nothing
+              p  -> Just . Password . pack $ p
+  in PostgresConfig
+    { host = pack $ connectHost pgc
+    , database = pack $ connectDatabase pgc
+    , user = pack $ connectUser pgc
+    , password = pass
+    }

--- a/src/Arbor/Postgres/Config.hs
+++ b/src/Arbor/Postgres/Config.hs
@@ -77,11 +77,11 @@ configToConnectInfo pgc =
               Nothing           -> ""
               Just (Password p) -> p
   in ConnectInfo
-    { connectHost = unpack $ host pgc
+    { connectHost     = unpack $ host pgc
     , connectDatabase = unpack $ database pgc
-    , connectUser = unpack $ user pgc
+    , connectUser     = unpack $ user pgc
     , connectPassword = unpack pass
-    , connectPort = 5432
+    , connectPort     = 5432
     }
 
 connectInfoToConfig :: PG.ConnectInfo -> PostgresConfig
@@ -90,8 +90,8 @@ connectInfoToConfig pgc =
               "" -> Nothing
               p  -> Just . Password . pack $ p
   in PostgresConfig
-    { host = pack $ connectHost pgc
+    { host     = pack $ connectHost pgc
     , database = pack $ connectDatabase pgc
-    , user = pack $ connectUser pgc
+    , user     = pack $ connectUser pgc
     , password = pass
     }

--- a/src/Arbor/Postgres/Core.hs
+++ b/src/Arbor/Postgres/Core.hs
@@ -18,21 +18,10 @@ import Network.URI
 import qualified Arbor.Postgres.Config      as Z
 import qualified Arbor.Postgres.Env         as E
 import qualified Data.Text                  as T
-import qualified Data.Text.Encoding         as T
 import qualified Database.PostgreSQL.Simple as PGS
 
 parseConfig :: Z.PostgresConfig -> ByteString
-parseConfig postgresConfig = do
-  let host       = postgresConfig ^. the @"host"
-  let dbname     = postgresConfig ^. the @"database"
-  let user       = postgresConfig ^. the @"user"
-  let mPassword  = postgresConfig ^. the @"password"
-  let kvPassword = case mPassword of
-        Just (Password password) -> [("password", password)]
-        Nothing                  -> []
-  let kvs = [("host", host), ("dbname", dbname), ("user", user)] <> kvPassword
-  let pairs = kvs <&> (\(k, v) -> k <> "='" <> v <> "'")
-  T.encodeUtf8 $ T.intercalate " " pairs
+parseConfig = PGS.postgreSQLConnectionString . Z.configToConnectInfo
 
 -- because we need a double quoted, not single quoted string,
 -- we need to explicitly not use sql interpolation here.


### PR DESCRIPTION
The current structure is a bit of a pain to work with if/when you
actually want PostgresSimple's default behaviour w.r.t default values
and reading from ENV vars and .pgpass files.

This adds a parser for ConnectInfo, and conversion functions between
ConnectInfo and PostgresConfig

Most significantly, I've changed `parseConfig` to use PostgresSimple's
in-built connection string builder, instead of the custom one we had,
which means we get all the fallback logic.